### PR TITLE
Removed dry-run flag

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,4 +45,4 @@ jobs:
       # Finally, we compile the sketch, using the FQBN that was set
       # in the build matrix.
       - name: Compile Sketch
-        run: cd src && arduino-cli compile --fqbn ${{ matrix.fqbn }} --dry-run
+        run: cd src && arduino-cli compile --fqbn ${{ matrix.fqbn }}


### PR DESCRIPTION
An explicit dry-run flag is not needed anymore according to https://forum.arduino.cc/index.php?topic=718310.0 